### PR TITLE
Fix!

### DIFF
--- a/src/navigator/LoggedOut.js
+++ b/src/navigator/LoggedOut.js
@@ -1,11 +1,11 @@
-import { createStackNavigator } from 'react-navigation'
+import { createAppContainer, createStackNavigator } from 'react-navigation'
 
 import Login from '../components/Login'
 
-const LoggedOutNavigator = createStackNavigator({
+const LoggedOutNavigator = createAppContainer (createStackNavigator({
   Login: {
     screen: Login
   }
-});
+}));
 
 export default LoggedOutNavigator

--- a/src/navigator/index.js
+++ b/src/navigator/index.js
@@ -1,9 +1,9 @@
-import { createSwitchNavigator } from 'react-navigation'
+import { createAppContainer, createSwitchNavigator } from 'react-navigation'
 
 import LoggedOutNavigator from './LoggedOut'
 import LoggedInNavigator from './LoggedIn'
 
-export const getRootNavigator = (loggedIn = false) => createSwitchNavigator(
+export const getRootNavigator = (loggedIn = false) => createAppContainer (createSwitchNavigator(
   {
     LoggedOut: {
       screen: LoggedOutNavigator
@@ -15,4 +15,4 @@ export const getRootNavigator = (loggedIn = false) => createSwitchNavigator(
   {
     initialRouteName: loggedIn ? 'LoggedIn' : 'LoggedOut'
   }
-);
+));


### PR DESCRIPTION
In react-navigation v3, `createStackNavigator` and `createSwitchNavigator` must wrapped with `createAppContainer`!

Without using `createAppContainer`, this error appeared:

> “Invariant Violation: The navigation prop is missing for this navigator”